### PR TITLE
Implemented Caching and Link support

### DIFF
--- a/lib/card_ui.dart
+++ b/lib/card_ui.dart
@@ -72,8 +72,11 @@ class CusCard extends StatelessWidget {
                   fit: BoxFit.cover,
                   placeholder: (context, url) => Container(
                     color: Colors.black12,
+                    child: const Center(
+                      child: CircularProgressIndicator(),
+                    ),
                   ),
-                  errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
+                  errorWidget: (context, url, error) => const Icon(Icons.error, color: Colors.white,),
                 ),
               ),
             )),
@@ -202,6 +205,9 @@ class NotiCard extends StatelessWidget {
                   fit: BoxFit.cover,
                   placeholder: (context, url) => Container(
                     color: Colors.black12,
+                      child: const Center(
+                        child: CircularProgressIndicator(),
+                      ),
                   ),
                   errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
                 ),

--- a/lib/card_ui.dart
+++ b/lib/card_ui.dart
@@ -73,7 +73,7 @@ class CusCard extends StatelessWidget {
                   placeholder: (context, url) => Container(
                     color: Colors.black12,
                   ),
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
                 ),
               ),
             )),
@@ -203,7 +203,7 @@ class NotiCard extends StatelessWidget {
                   placeholder: (context, url) => Container(
                     color: Colors.black12,
                   ),
-                  errorWidget: (context, url, error) => Icon(Icons.error),
+                  errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
                 ),
               ),
             )),

--- a/lib/card_ui.dart
+++ b/lib/card_ui.dart
@@ -67,9 +67,13 @@ class CusCard extends StatelessWidget {
               margin: EdgeInsets.all(7),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(5.0),
-                child: Image(
-                  image: CachedNetworkImageProvider(link),
+                child: CachedNetworkImage(
+                  imageUrl: link,
                   fit: BoxFit.cover,
+                  placeholder: (context, url) => Container(
+                    color: Colors.black12,
+                  ),
+                  errorWidget: (context, url, error) => Icon(Icons.error),
                 ),
               ),
             )),
@@ -193,9 +197,13 @@ class NotiCard extends StatelessWidget {
                 borderRadius: BorderRadius.only(
                     topLeft: Radius.circular(5),
                     bottomLeft: Radius.circular(5)),
-                child: Image(
-                  image: CachedNetworkImageProvider(imgUrl),
+                child: CachedNetworkImage(
+                  imageUrl: imgUrl,
                   fit: BoxFit.cover,
+                  placeholder: (context, url) => Container(
+                    color: Colors.black12,
+                  ),
+                  errorWidget: (context, url, error) => Icon(Icons.error),
                 ),
               ),
             )),

--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -35,6 +35,9 @@ CREATE TABLE $tableNotifications (
   ${NotificationFields.imageUrl} $textType,
   ${NotificationFields.title} $textType,
   ${NotificationFields.description} $textType,
+  ${NotificationFields.body} $textType,
+  ${NotificationFields.htmlBody} $textType,
+  ${NotificationFields.category} $integerType,
   ${NotificationFields.time} $textType
   )
 ''');

--- a/lib/display.dart
+++ b/lib/display.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:intl/intl.dart';
+import 'package:html/dom.dart' as html;
+import 'package:url_launcher/url_launcher.dart';
 
 class DisplayPost extends StatelessWidget {
   DisplayPost(
@@ -197,6 +199,17 @@ class SliverListBldr extends StatelessWidget {
   final String date;
   final String? htmlBody;
 
+  /// Launches any url in browser, We are this method because
+  /// launch() function is deprecated.
+  Future<void> _launchInBrowser(Uri url) async {
+    if (!await launchUrl(
+      url,
+      mode: LaunchMode.externalApplication,
+    )) {
+      throw Exception('Could not launch $url');
+    }
+  }
+
 
   @override
   Widget build(BuildContext context) {
@@ -213,7 +226,15 @@ class SliverListBldr extends StatelessWidget {
               color: Colors.white,
               fontSize: FontSize(15.0),
               fontFamily: "Cambo",
+            ),
+            "a" : Style(
+              color: Colors.blue,
             )
+          },
+          onLinkTap:  (String? url, Map<String, String> attributes, html.Element? element,) {
+            if (url != null) {
+              _launchInBrowser(Uri.parse(url));
+            }
           },
         );
 

--- a/lib/display.dart
+++ b/lib/display.dart
@@ -129,7 +129,7 @@ class SliverAppBarBldr extends StatelessWidget {
             placeholder: (context, url) => Container(
               color: Colors.black12,
             ),
-            errorWidget: (context, url, error) => Icon(Icons.error),
+            errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
           ),
         ),
       ),

--- a/lib/display.dart
+++ b/lib/display.dart
@@ -128,6 +128,9 @@ class SliverAppBarBldr extends StatelessWidget {
             fit: BoxFit.cover,
             placeholder: (context, url) => Container(
               color: Colors.black12,
+              child: const Center(
+                child: CircularProgressIndicator(),
+              ),
             ),
             errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
           ),

--- a/lib/display.dart
+++ b/lib/display.dart
@@ -123,10 +123,14 @@ class SliverAppBarBldr extends StatelessWidget {
             return FullScreen(imgUrl: imgUrl);
           }));
           },
-          child : Image(
-          image: CachedNetworkImageProvider(imgUrl),
-          fit: BoxFit.cover,
-        ),
+          child : CachedNetworkImage(
+            imageUrl: imgUrl,
+            fit: BoxFit.cover,
+            placeholder: (context, url) => Container(
+              color: Colors.black12,
+            ),
+            errorWidget: (context, url, error) => Icon(Icons.error),
+          ),
         ),
       ),
     );

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -79,7 +79,6 @@ class _MainPageState extends State<MainPage> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      extendBody: true,
       appBar: AppBar(
         title: const Text('The HIT Times'),
         leading: Container(

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -79,6 +79,7 @@ class _MainPageState extends State<MainPage> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      extendBody: true,
       appBar: AppBar(
         title: const Text('The HIT Times'),
         leading: Container(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,9 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
         imageUrl: message.notification!.android!.imageUrl!,
         title: message.notification!.title!,
         description: message.notification!.body!,
+        body: message.data['body']!,
+        htmlBody: message.data['htmlBody']!,
+        category: int.parse(message.data['category']!),
         createdTime:  DateTime.now()
       )
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
       NotificationModel.Notification(
         imageUrl: message.notification!.android!.imageUrl!,
         title: message.notification!.title!,
-        description: message.notification!.body!,
+        description: message.data['description'],
         body: message.data['body']!,
         htmlBody: message.data['htmlBody']!,
         category: int.parse(message.data['category']!),

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -3,7 +3,7 @@ final String tableNotifications = 'notifications';
 class NotificationFields {
   static final List<String> values = [
     /// Add all fields
-    id, imageUrl, title, description, time
+    id, imageUrl, title,  body, description, time, htmlBody, category,
   ];
 
   static final String id = '_id';
@@ -11,6 +11,9 @@ class NotificationFields {
   static final String title = 'title';
   static final String description = 'description';
   static final String time = 'time';
+  static final String body = 'body';
+  static final String htmlBody = 'htmlBody';
+  static final String category = 'category';
 }
 
 class Notification {
@@ -19,6 +22,9 @@ class Notification {
   final String title;
   final String description;
   final DateTime createdTime;
+  final String htmlBody;
+  final int category;
+  final String body;
 
   const Notification({
     this.id,
@@ -26,6 +32,9 @@ class Notification {
     required this.title,
     required this.description,
     required this.createdTime,
+    required this.htmlBody,
+    required this.category,
+    required this.body,
   });
 
   Notification copy({
@@ -34,6 +43,9 @@ class Notification {
     int? number,
     String? title,
     String? description,
+    String? body,
+    String? htmlBody,
+    int? category,
     DateTime? createdTime,
   }) =>
       Notification(
@@ -42,6 +54,9 @@ class Notification {
         title: title ?? this.title,
         description: description ?? this.description,
         createdTime: createdTime ?? this.createdTime,
+        body: body ?? this.body,
+        htmlBody: htmlBody ?? this.htmlBody,
+        category: category ?? this.category,
       );
 
   static Notification fromJson(Map<String, Object?> json) => Notification(
@@ -50,6 +65,9 @@ class Notification {
         title: json[NotificationFields.title] as String,
         description: json[NotificationFields.description] as String,
         createdTime: DateTime.parse(json[NotificationFields.time] as String),
+        body: json[NotificationFields.body] as String,
+        htmlBody: json[NotificationFields.htmlBody] as String,
+        category: json[NotificationFields.category] as int,
       );
 
   Map<String, Object?> toJson() => {
@@ -58,5 +76,8 @@ class Notification {
         NotificationFields.imageUrl: imageUrl,
         NotificationFields.description: description,
         NotificationFields.time: createdTime.toIso8601String(),
+        NotificationFields.body: body,
+        NotificationFields.htmlBody: htmlBody,
+        NotificationFields.category: category,
       };
 }

--- a/lib/news.dart
+++ b/lib/news.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:the_hit_times_app/util/cache_manager.dart';
 
 import 'bookmark_service/bookmark_service.dart';
@@ -69,6 +70,15 @@ class NewsState extends State<News> {
     print("Fetching... $url");
     var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
+
+    final connectivityResult = await (Connectivity().checkConnectivity());
+    if (connectivityResult == ConnectivityResult.none) {
+      ScaffoldMessenger.of(context).showSnackBar( const SnackBar(
+        backgroundColor: Colors.green,
+        content: const Text('No Internet Connection!'),
+      ));
+    }
+
     setState(() {
       page = page + 1;
 

--- a/lib/news.dart
+++ b/lib/news.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:the_hit_times_app/util/cache_manager.dart';
+
 import 'bookmark_service/bookmark_service.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:photo_view/photo_view.dart';
 import 'package:the_hit_times_app/card_ui.dart';
 import 'package:intl/intl.dart';
@@ -66,12 +67,12 @@ class NewsState extends State<News> {
     final String url =
         "https://tht-admin.onrender.com/api/posts?limit=$limit&page=$page";
     print("Fetching... $url");
-    var res = await http.get(Uri.parse(Uri.encodeFull(url)),
+    var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
     setState(() {
       page = page + 1;
 
-      var resBody = json.decode(res.body);
+      var resBody = json.decode(res);
       allPosts = PostList.fromJson(resBody);
       allPosts.posts.map((e) => print(e.body));
       if (resBody.length < limit) {

--- a/lib/notidisplay.dart
+++ b/lib/notidisplay.dart
@@ -125,6 +125,9 @@ class SliverAppBarBldr extends StatelessWidget {
           fit: BoxFit.cover,
           placeholder: (context, url) => Container(
             color: Colors.black12,
+            child: const Center(
+              child: CircularProgressIndicator(),
+            ),
           ),
           errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
         ),

--- a/lib/notidisplay.dart
+++ b/lib/notidisplay.dart
@@ -120,9 +120,13 @@ class SliverAppBarBldr extends StatelessWidget {
             return FullScreen(imgUrl: imgUrl);
           }));
           },
-        child: Image(
-          image: CachedNetworkImageProvider(imgUrl),
+        child: CachedNetworkImage(
+          imageUrl: imgUrl,
           fit: BoxFit.cover,
+          placeholder: (context, url) => Container(
+            color: Colors.black12,
+          ),
+          errorWidget: (context, url, error) => Icon(Icons.error),
         ),
         ),
       ),

--- a/lib/notidisplay.dart
+++ b/lib/notidisplay.dart
@@ -126,7 +126,7 @@ class SliverAppBarBldr extends StatelessWidget {
           placeholder: (context, url) => Container(
             color: Colors.black12,
           ),
-          errorWidget: (context, url, error) => Icon(Icons.error),
+          errorWidget: (context, url, error) => Icon(Icons.error, color: Colors.white,),
         ),
         ),
       ),

--- a/lib/notification_service/notification_service.dart
+++ b/lib/notification_service/notification_service.dart
@@ -55,12 +55,18 @@ class NotificationService {
         print(" hi "+message.notification!.android!.imageUrl!);
         print(" hi2 ${message.notification!.title}");
         print(" hi3 ${message.notification!.body}");
+        print(" hi3 ${message.data["body"]}");
+        print(" hi3 ${message.data["htmlBody"]}");
+        print(" hi3 ${message.data["category"]}");
 
         await NotificationDatabase.instance.create(
           Notification(
           imageUrl: message.notification!.android!.imageUrl!,
           title: message.notification!.title!,
-          description: message.notification!.body!, 
+          description: message.notification!.body!,
+          body: message.data['body']!,
+          htmlBody: message.data['htmlBody']!,
+          category: int.parse(message.data['category']!),
           createdTime:  DateTime.now(),)
           );
 

--- a/lib/notification_service/notification_service.dart
+++ b/lib/notification_service/notification_service.dart
@@ -63,7 +63,7 @@ class NotificationService {
           Notification(
           imageUrl: message.notification!.android!.imageUrl!,
           title: message.notification!.title!,
-          description: message.notification!.body!,
+          description: message.data['description'],
           body: message.data['body']!,
           htmlBody: message.data['htmlBody']!,
           category: int.parse(message.data['category']!),

--- a/lib/notify.dart
+++ b/lib/notify.dart
@@ -73,7 +73,7 @@ class Notify extends State<DispNoti> {
                         return InkWell(
                           onTap: () {
                             Navigator.of(context).push(MaterialPageRoute(
-                              builder: (BuildContext context) => Notidisplay(
+                              builder: (BuildContext context) => DisplayPost(
                                   pIndex: index,
                                   title: notes[index].title,
                                   body: notes[index].description,
@@ -82,7 +82,8 @@ class Notify extends State<DispNoti> {
                                       .createdTime
                                       .toIso8601String(),
                                   description: notes[index].description,
-                                  category: 0),
+                                  category: notes[index].category,
+                                htmlBody: notes[index].htmlBody,),
                             ));
                           },
                           child: NotiCard(

--- a/lib/util/cache_manager.dart
+++ b/lib/util/cache_manager.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:http/http.dart' as http;
+
+class Http {
+  static Future<http.Response> get(String url, {required Map<String, String> headers}) async {
+    var file = await DefaultCacheManager().getSingleFile(url);
+    if (await file.exists()) {
+      return http.Response(await file.readAsString(), 200);
+    } else {
+      var response = await http.get(Uri.parse(url), headers: headers);
+      if (response.statusCode == 200) {
+        DefaultCacheManager().putFile(url,response.bodyBytes);
+      }
+      return response;
+    }
+  }
+
+  static Future<String> getBody(String url, {required Map<String, String> headers}) async {
+    var file = await DefaultCacheManager().getSingleFile(url);
+    if (await file.exists()) {
+      return await file.readAsString();
+    } else {
+      var response = await http.get(Uri.parse(url), headers: headers);
+      if (response.statusCode == 200) {
+        DefaultCacheManager().putFile(url,response.bodyBytes);
+      }
+      return response.body;
+    }
+  }
+}

--- a/lib/util/cache_manager.dart
+++ b/lib/util/cache_manager.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 
@@ -6,28 +7,43 @@ class Http {
   @Deprecated('Use getBody instead. Characters are lost when using this method')
   /// TODO: Fix characters being lost when using this method
   static Future<http.Response> get(String url, {required Map<String, String> headers}) async {
-    var file = await DefaultCacheManager().getSingleFile(url);
-    if (await file.exists()) {
-      return http.Response(await file.readAsString(), 200);
-    } else {
+    try {
       var response = await http.get(Uri.parse(url), headers: headers);
       if (response.statusCode == 200) {
         DefaultCacheManager().putFile(url,response.bodyBytes);
       }
       return response;
+    } catch (e) {
+      debugPrint("Loading Failed: $url");
+      debugPrint("Loading Cache: $url");
     }
+
+    var file = await DefaultCacheManager().getSingleFile(url);
+    if (await file.exists()) {
+      return http.Response(await file.readAsString(), 200);
+    }
+
+    return http.Response("", 404);
   }
 
   static Future<String> getBody(String url, {required Map<String, String> headers}) async {
-    var file = await DefaultCacheManager().getSingleFile(url);
-    if (await file.exists()) {
-      return await file.readAsString();
-    } else {
+
+    try {
       var response = await http.get(Uri.parse(url), headers: headers);
       if (response.statusCode == 200) {
         DefaultCacheManager().putFile(url,response.bodyBytes);
       }
       return response.body;
+    } catch (e) {
+      debugPrint("Loading Failed: $url");
+      debugPrint("Loading Cache: $url");
     }
+
+    var file = await DefaultCacheManager().getSingleFile(url);
+    if (await file.exists()) {
+      return await file.readAsString();
+    }
+
+    return "";
   }
 }

--- a/lib/util/cache_manager.dart
+++ b/lib/util/cache_manager.dart
@@ -2,30 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 
+/// Custom Http Class with cache implementation.
 class Http {
 
-  @Deprecated('Use getBody instead. Characters are lost when using this method')
-  /// TODO: Fix characters being lost when using this method
-  static Future<http.Response> get(String url, {required Map<String, String> headers}) async {
-    try {
-      var response = await http.get(Uri.parse(url), headers: headers);
-      if (response.statusCode == 200) {
-        DefaultCacheManager().putFile(url,response.bodyBytes);
-      }
-      return response;
-    } catch (e) {
-      debugPrint("Loading Failed: $url");
-      debugPrint("Loading Cache: $url");
-    }
-
-    var file = await DefaultCacheManager().getSingleFile(url);
-    if (await file.exists()) {
-      return http.Response(await file.readAsString(), 200);
-    }
-
-    return http.Response("", 404);
-  }
-
+  /// Returns a Http.Body response based on availability
+  /// if a GET request fails, it try to returns from cache.
   static Future<String> getBody(String url, {required Map<String, String> headers}) async {
 
     try {
@@ -39,11 +20,13 @@ class Http {
       debugPrint("Loading Cache: $url");
     }
 
+    // Try to load from cache for specific Url.
     var file = await DefaultCacheManager().getSingleFile(url);
     if (await file.exists()) {
       return await file.readAsString();
     }
 
+    // Return an empty response if there is no cache available.
     return "";
   }
 }

--- a/lib/util/cache_manager.dart
+++ b/lib/util/cache_manager.dart
@@ -1,10 +1,10 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 
 class Http {
+
+  @Deprecated('Use getBody instead. Characters are lost when using this method')
+  /// TODO: Fix characters being lost when using this method
   static Future<http.Response> get(String url, {required Map<String, String> headers}) async {
     var file = await DefaultCacheManager().getSingleFile(url);
     if (await file.exists()) {

--- a/lib/weeklie.dart
+++ b/lib/weeklie.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:the_hit_times_app/bookmark_service/bookmark_service.dart';
 import 'package:the_hit_times_app/card_ui.dart';
 import 'package:the_hit_times_app/database_helper.dart';
@@ -10,6 +9,7 @@ import 'package:the_hit_times_app/models/postmodel.dart';
 import 'package:the_hit_times_app/news.dart';
 import 'package:the_hit_times_app/display.dart';
 import 'package:the_hit_times_app/models/notification.dart' as nf;
+import 'package:the_hit_times_app/util/cache_manager.dart';
 
 class Weeklies extends StatefulWidget {
   @override
@@ -47,12 +47,12 @@ class _WeekliesState extends State<Weeklies> {
     final String url =
         "https://tht-admin.onrender.com/api/posts/weeklies?limit=$limit&page=$page";
     print("Fetching... $url");
-    var res = await http.get(Uri.parse(Uri.encodeFull(url)),
+    var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
     setState(() {
       page = page + 1;
 
-      var resBody = json.decode(res.body);
+      var resBody = json.decode(res);
       allPosts = PostList.fromJson(resBody);
       allPosts.posts.map((e) => print(e.body));
       if (resBody.length < limit) {
@@ -245,12 +245,12 @@ class _AppXState extends State<AppX> {
     final String url =
         "https://tht-admin.onrender.com/api/posts/appx?limit=$limit&page=$page";
     print("Fetching... $url");
-    var res = await http.get(Uri.parse(Uri.encodeFull(url)),
+    var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
     setState(() {
       page = page + 1;
 
-      var resBody = json.decode(res.body);
+      var resBody = json.decode(res);
       allPosts = PostList.fromJson(resBody);
       allPosts.posts.map((e) => print(e.body));
       if (resBody.length < limit) {
@@ -434,12 +434,12 @@ class _GazetteState extends State<Gazette> {
     final String url =
         "https://tht-admin.onrender.com/api/posts/gazette?limit=$limit&page=$page";
     print("Fetching... $url");
-    var res = await http.get(Uri.parse(Uri.encodeFull(url)),
+    var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
     setState(() {
       page = page + 1;
 
-      var resBody = json.decode(res.body);
+      var resBody = json.decode(res);
       allPosts = PostList.fromJson(resBody);
       allPosts.posts.map((e) => print(e.body));
       if (resBody.length < limit) {
@@ -633,12 +633,12 @@ class _ReportopolisState extends State<Reportopolis> {
     final String url =
         "https://tht-admin.onrender.com/api/posts/reportopolis?limit=$limit&page=$page";
     print("Fetching... $url");
-    var res = await http.get(Uri.parse(Uri.encodeFull(url)),
+    var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
     setState(() {
       page = page + 1;
 
-      var resBody = json.decode(res.body);
+      var resBody = json.decode(res);
       allPosts = PostList.fromJson(resBody);
       allPosts.posts.map((e) => print(e.body));
       if (resBody.length < limit) {

--- a/lib/weeklie.dart
+++ b/lib/weeklie.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:the_hit_times_app/bookmark_service/bookmark_service.dart';
 import 'package:the_hit_times_app/card_ui.dart';
@@ -49,6 +50,13 @@ class _WeekliesState extends State<Weeklies> {
     print("Fetching... $url");
     var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
+    final connectivityResult = await (Connectivity().checkConnectivity());
+    if (connectivityResult == ConnectivityResult.none) {
+      ScaffoldMessenger.of(context).showSnackBar( const SnackBar(
+        backgroundColor: Colors.green,
+        content: const Text('No Internet Connection!'),
+      ));
+    }
     setState(() {
       page = page + 1;
 
@@ -247,6 +255,13 @@ class _AppXState extends State<AppX> {
     print("Fetching... $url");
     var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
+    final connectivityResult = await (Connectivity().checkConnectivity());
+    if (connectivityResult == ConnectivityResult.none) {
+      ScaffoldMessenger.of(context).showSnackBar( const SnackBar(
+        backgroundColor: Colors.green,
+        content: const Text('No Internet Connection!'),
+      ));
+    }
     setState(() {
       page = page + 1;
 
@@ -436,6 +451,13 @@ class _GazetteState extends State<Gazette> {
     print("Fetching... $url");
     var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
+    final connectivityResult = await (Connectivity().checkConnectivity());
+    if (connectivityResult == ConnectivityResult.none) {
+      ScaffoldMessenger.of(context).showSnackBar( const SnackBar(
+        backgroundColor: Colors.green,
+        content: const Text('No Internet Connection!'),
+      ));
+    }
     setState(() {
       page = page + 1;
 
@@ -635,6 +657,13 @@ class _ReportopolisState extends State<Reportopolis> {
     print("Fetching... $url");
     var res = await Http.getBody(url,
         headers: {"Accept": "application/json"});
+    final connectivityResult = await (Connectivity().checkConnectivity());
+    if (connectivityResult == ConnectivityResult.none) {
+      ScaffoldMessenger.of(context).showSnackBar( const SnackBar(
+        backgroundColor: Colors.green,
+        content: const Text('No Internet Connection!'),
+      ));
+    }
     setState(() {
       page = page + 1;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   crypto:
     dependency: transitive
     description:
@@ -223,13 +223,13 @@ packages:
     source: hosted
     version: "0.7.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
-      sha256: "32cd900555219333326a2d0653aaaf8671264c29befa65bbd9856d204a4c9fb3"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   flutter_html:
     dependency: "direct main"
     description:
@@ -316,10 +316,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material:
     dependency: "direct main"
     description:
@@ -364,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   octo_image:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -432,14 +432,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -625,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timezone:
     dependency: transitive
     description:
@@ -750,5 +742,5 @@ packages:
     source: hosted
     version: "5.4.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "77a180d6938f78ca7d2382d2240eb626c0f6a735d0bfdce227d8ffb80f95c48b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
   crypto:
     dependency: transitive
     description:
@@ -368,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   shared_preferences: ^2.0.18
   flutter_html: ^3.0.0-beta.2
   flutter_cache_manager: ^3.3.1
+  connectivity_plus: ^4.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   emailjs: ^1.1.0
   shared_preferences: ^2.0.18
   flutter_html: ^3.0.0-beta.2
+  flutter_cache_manager: ^3.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Switched from `http.get` to a custom class `http` with a `getBody()` method i.e. `http.getBody(url, headers)`. https://github.com/the-hit-times/The-HIT-Times-App-Flutter/commit/08f08418af882217cb2597ff5a0f3b831b1413c6
- Switched from **CachedNetworkImageProvider** to **CachedNetworkImage** to handle loading errors and proving a placeholder image while loading. https://github.com/the-hit-times/The-HIT-Times-App-Flutter/commit/2904d01f2c1805300b6859b58d4c7f9517da8f99
- Added new dependency `flutter_cache_manager` to store https responses. 

**Note**:  Custom http class have `get()` method that returns a `Response` Object but there are some issues with non-english characters are lost. That's why use `getBody()` because it returns a string without any lost of data. 